### PR TITLE
fix: appbar width breakpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ yarn add responsive-ui
 - Support **ES Module** and **Common JS**.
 - Support **Server-side Rendering**.
 - **TypeScript** and **Sass** as First Class Citizen.
-- Compactible with [Svelte](https://svelte.dev/) and [SvelteKit](https://kit.svelte.dev/).
+- Compatible with [Svelte](https://svelte.dev/) and [SvelteKit](https://kit.svelte.dev/).
 
 ## 💅 Component List
 

--- a/components/app-bar/src/AppBar.svelte
+++ b/components/app-bar/src/AppBar.svelte
@@ -183,6 +183,7 @@
 
 <style lang="scss" global>
   $sm: 576px;
+  $md: 768px;
   $height: 55px;
 
   .resp-app-bar {
@@ -239,7 +240,7 @@
       display: flex;
       justify-content: space-between;
 
-      @media (min-width: $sm) {
+      @media (min-width: $md) {
         width: 80%;
       }
     }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/49902829/150921635-78b19ce8-04b0-4851-aab6-0f33a0f306ef.png)

in md breakpoint leading items would clip into the trailing and logo
these commits can make appbar fill whole width when below md breakpoint

also fix readme typo