### PR TITLE
fix: bottom sheet height

### DIFF
--- a/components/action-sheet/src/ActionSheet.svelte
+++ b/components/action-sheet/src/ActionSheet.svelte
@@ -8,7 +8,7 @@
 
   let className = "";
   let selectedIndex = 0;
-  let modalHeight = 0;
+  let modalHeight = "100%";
   export { className as class };
   export let selectedKey = "";
   export let caption = "";
@@ -100,7 +100,7 @@
 
 <BottomSheet
   bind:open
-  bind:height={modalHeight}
+  height={modalHeight}
   class={className}
   {maskClosable}
   {closable}
@@ -139,7 +139,7 @@
   </header>
   <ul
     class="resp-action-sheet__body"
-    style="height: {modalHeight - 180}px"
+    style={`height: calc(${modalHeight} - 180px)`}
     on:change={handleSelectOption}
   >
     {#each options as { label, value, disabled = false, selected = false, ...otherProps } (`${selectedKey}.${value}`)}

--- a/components/action-sheet/src/ActionSheet.svelte
+++ b/components/action-sheet/src/ActionSheet.svelte
@@ -100,7 +100,7 @@
 
 <BottomSheet
   bind:open
-  height={modalHeight}
+  bind:height={modalHeight}
   class={className}
   {maskClosable}
   {closable}

--- a/components/action-sheet/src/ActionSheet.svelte
+++ b/components/action-sheet/src/ActionSheet.svelte
@@ -8,7 +8,7 @@
 
   let className = "";
   let selectedIndex = 0;
-  let modalHeight = "100%";
+  let modalHeight = 0;
   export { className as class };
   export let selectedKey = "";
   export let caption = "";
@@ -139,7 +139,7 @@
   </header>
   <ul
     class="resp-action-sheet__body"
-    style={`height: calc(${modalHeight} - 180px)`}
+    style={`height: ${modalHeight - 180}px`}
     on:change={handleSelectOption}
   >
     {#each options as { label, value, disabled = false, selected = false, ...otherProps } (`${selectedKey}.${value}`)}

--- a/components/bottom-sheet/src/BottomSheet.svelte
+++ b/components/bottom-sheet/src/BottomSheet.svelte
@@ -5,11 +5,11 @@
   let className = "";
   export { className as class };
   export let open = false;
-  export let height = 0;
   export let maskClosable = true;
   export let closable = true;
   export let draggable = true;
   export let style = "";
+  export let height = "100%";
 
   const tween = tweened(1, {
     duration: 150
@@ -21,13 +21,8 @@
     void tween.set(1);
   }
 
-  let innerHeight = 0;
-
-  $: height = innerHeight * 0.85;
   $: offset = 1 - $tween;
 </script>
-
-<svelte:window bind:innerHeight />
 
 <div
   class="resp-bottom-sheet__overlay"
@@ -37,7 +32,7 @@
 />
 <div
   class="resp-bottom-sheet {className}"
-  style:height="{height}px"
+  style:height
   {...$$restProps}
   style:visibility={offset <= 0 ? "hidden" : "visible"}
   style={`transform: translateY(${$tween * 100}%); ${style}`}

--- a/components/bottom-sheet/src/BottomSheet.svelte
+++ b/components/bottom-sheet/src/BottomSheet.svelte
@@ -17,6 +17,10 @@
     duration: 150
   });
 
+  onMount(() => {
+    innerHeight = window.innerHeight;
+  });
+
   $: if (open) {
     void tween.set(0);
   } else {
@@ -25,10 +29,6 @@
 
   $: offset = 1 - $tween;
   $: height = innerHeight * 0.85;
-
-  onMount(() => {
-    innerHeight = window.innerHeight;
-  });
 </script>
 
 <div

--- a/components/bottom-sheet/src/BottomSheet.svelte
+++ b/components/bottom-sheet/src/BottomSheet.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { noop } from "svelte/internal";
   import { tweened } from "svelte/motion";
+  import { onMount } from "svelte";
 
   let className = "";
   export { className as class };
@@ -9,7 +10,8 @@
   export let closable = true;
   export let draggable = true;
   export let style = "";
-  export let height = "100%";
+  export let height = 0;
+  let innerHeight = 0;
 
   const tween = tweened(1, {
     duration: 150
@@ -22,6 +24,11 @@
   }
 
   $: offset = 1 - $tween;
+  $: height = innerHeight * 0.85;
+
+  onMount(() => {
+    innerHeight = window.innerHeight;
+  });
 </script>
 
 <div
@@ -32,7 +39,7 @@
 />
 <div
   class="resp-bottom-sheet {className}"
-  style:height
+  style:height={`${height}px`}
   {...$$restProps}
   style:visibility={offset <= 0 ? "hidden" : "visible"}
   style={`transform: translateY(${$tween * 100}%); ${style}`}

--- a/components/bottom-sheet/types/index.d.ts
+++ b/components/bottom-sheet/types/index.d.ts
@@ -4,7 +4,7 @@ export interface BottomSheetProps {
   id?: string;
   class?: string;
   open?: boolean;
-  height?: number;
+  height?: string;
   draggable?: boolean;
   maskClosable?: boolean;
   closable?: boolean;

--- a/components/bottom-sheet/types/index.d.ts
+++ b/components/bottom-sheet/types/index.d.ts
@@ -4,7 +4,7 @@ export interface BottomSheetProps {
   id?: string;
   class?: string;
   open?: boolean;
-  height?: string;
+  height?: number;
   draggable?: boolean;
   maskClosable?: boolean;
   closable?: boolean;


### PR DESCRIPTION
Problem: Bottom sheet would not be the correct height.

This PR foregoes javascript calculation of height and uses CSS instead.

![image](https://user-images.githubusercontent.com/49902829/174955710-a605371d-ad35-4d9b-b504-8aa0ff538faf.png)
