### PR TITLE
fix: calendar hover style

### DIFF
--- a/components/date-picker/src/Calendar.svelte
+++ b/components/date-picker/src/Calendar.svelte
@@ -250,9 +250,18 @@
         color: #bebebe;
       }
 
-      &:hover {
-        background: #fc4451;
-        color: #fff;
+      @media (hover) and (pointer: fine) {
+        &:hover {
+          background: #fc4451;
+          color: #fff;
+        }
+      }
+
+      @media (hover: none) and (pointer: coarse) {
+        &:active {
+          background: #fc4451;
+          color: #fff;
+        }
       }
     }
 

--- a/components/date-picker/src/DatePicker.svelte
+++ b/components/date-picker/src/DatePicker.svelte
@@ -15,7 +15,6 @@
 
   let className = "";
   export { className as class };
-  export let placeholder = "DD/MM/YYYY";
   export let value = "";
   export let name = "";
   export let open = false;
@@ -131,7 +130,6 @@
     {name}
     {disabled}
     size="20"
-    {placeholder}
     {readonly}
     {min}
     {max}

--- a/components/date-picker/types/index.d.ts
+++ b/components/date-picker/types/index.d.ts
@@ -3,7 +3,6 @@ import type { SvelteComponentTyped } from "svelte/internal";
 export interface DatePickerProps {
   class?: string;
   open?: boolean;
-  placeholder?: string;
   value?: string;
   ref?: HTMLInputElement;
   name?: string;

--- a/stories/DatePicker.stories.svelte
+++ b/stories/DatePicker.stories.svelte
@@ -7,7 +7,6 @@
   title="Components/Date Picker"
   component={DatePicker}
   argTypes={{
-    placeholder: { control: "text" },
     name: { control: "text" },
     disabled: { control: "boolean" },
     readonly: { control: "boolean" },
@@ -27,12 +26,7 @@
   />
 </Template>
 
-<Story
-  name="Default"
-  args={{
-    size: "middle"
-  }}
-/>
+<Story name="Default" />
 
 <Story
   name="With Default Value"


### PR DESCRIPTION
- using `@media` queries to detect whether it's a touchscreen device or not
- if can hover, will apply :hover styles
- if cannot hover, will apply :active styles
- fix stories
- remove `placeholder` attribute