### PR TITLE
fix: date-picker `form` can use `string` or `HTMLFormElement`

### DIFF
--- a/components/date-picker/types/index.d.ts
+++ b/components/date-picker/types/index.d.ts
@@ -11,7 +11,7 @@ export interface DatePickerProps {
   bordered?: boolean;
   useNative?: boolean;
   spanWidth?: boolean;
-  form?: string | HTMLFormElement;
+  form?: string;
   placeholder?: string;
   min?: string;
   max?: string;

--- a/components/date-picker/types/index.d.ts
+++ b/components/date-picker/types/index.d.ts
@@ -11,7 +11,7 @@ export interface DatePickerProps {
   bordered?: boolean;
   useNative?: boolean;
   spanWidth?: boolean;
-  form?: HTMLFormElement;
+  form?: string | HTMLFormElement;
   placeholder?: string;
   min?: string;
   max?: string;


### PR DESCRIPTION
allow `form` attribute to take either `string` or `HTMLFormElement` types